### PR TITLE
Cache bug

### DIFF
--- a/Build/ModulePackage.targets
+++ b/Build/ModulePackage.targets
@@ -111,6 +111,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       <InstallInclude Include="**\*.bmp" Exclude="packages\**;node_modules\**;clientApp\**;client-app\**" />
       <InstallInclude Include="**\*.xml" Exclude="packages\**;node_modules\**;clientApp\**;client-app\**;bin\**" />
       <InstallInclude Include="**\web.config" Exclude="packages\**;node_modules\**;clientApp\**;client-app\**" />
+	  <InstallInclude Include="**\*.xml.resources" Exclude="Config/ogConfig*.xml.resources;Config/ogSettings*.xml.resources"/>
     </ItemGroup>
 
     <CreateItem Include="$(DNNFileName).dnn">

--- a/Modules/WillStrohl.OpenGraph/WillStrohl.Modules.OpenGraph.vbproj
+++ b/Modules/WillStrohl.OpenGraph/WillStrohl.Modules.OpenGraph.vbproj
@@ -105,14 +105,29 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetNuke, Version=9.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetNuke.Core.9.4.0\lib\net45\DotNetNuke.dll</HintPath>
+    <Reference Include="DotNetNuke, Version=9.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetNuke.Core.9.11.0\lib\net45\DotNetNuke.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetNuke.DependencyInjection, Version=9.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetNuke.DependencyInjection.9.11.0\lib\netstandard2.0\DotNetNuke.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetNuke.Instrumentation, Version=9.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetNuke.Instrumentation.9.11.0\lib\net45\DotNetNuke.Instrumentation.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetNuke.log4net, Version=3.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetNuke.Instrumentation.9.11.0\lib\net45\DotNetNuke.log4net.dll</HintPath>
     </Reference>
     <Reference Include="DotNetNuke.Web">
       <HintPath>..\..\References\DotNetNuke\DotNetNuke.Web.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationBlocks.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetNuke.Core.9.4.0\lib\net45\Microsoft.ApplicationBlocks.Data.dll</HintPath>
+      <HintPath>..\..\packages\DotNetNuke.Core.9.11.0\lib\net45\Microsoft.ApplicationBlocks.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/Modules/WillStrohl.OpenGraph/WillStrohl.OpenGraph.dnn
+++ b/Modules/WillStrohl.OpenGraph/WillStrohl.OpenGraph.dnn
@@ -16,7 +16,7 @@
       <releaseNotes src="releasenotes.txt" />
       <azureCompatible>True</azureCompatible>
       <dependencies>
-        <dependency type="coreversion">09.04.00</dependency>
+        <dependency type="coreversion">09.11.00</dependency>
       </dependencies>
       <components>
         <component type="Module">

--- a/Modules/WillStrohl.OpenGraph/packages.config
+++ b/Modules/WillStrohl.OpenGraph/packages.config
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetNuke.Core" version="9.4.0" targetFramework="net472" />
+  <package id="DotNetNuke.Core" version="9.11.0" targetFramework="net472" />
+  <package id="DotNetNuke.DependencyInjection" version="9.11.0" targetFramework="net472" />
+  <package id="DotNetNuke.Instrumentation" version="9.11.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue #31 

## Description
<!--- Describe your changes in detail -->
During the build of the installer, the files in the Config/ folder HandlerMerge-Add.xml.resources and HandlerMerge-Remove.xml.resources were not being copied. This caused a NullReferenceException in the method responsible for setting and managing the module configuration, preventing the settings from being read and the Open Graph Protocol from being enabled. To resolve this, I modified the ModulePackage.targets file to include these files, which effectively fixed the issue. I also updated the DNN dependencies to 9.11.00.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested locally

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/2c4e6d6b-4736-4fa1-9fe2-f8232f619ed6)
![image](https://github.com/user-attachments/assets/470fee7d-0ef8-4693-ab72-0a9959317ab5)
![image](https://github.com/user-attachments/assets/a66076e9-9035-4e5d-ad66-1116d8ce59a0)
![image](https://github.com/user-attachments/assets/38b4feac-7e3e-4d7b-84ae-35fc7c41997d)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.